### PR TITLE
Fix some typos in meow-cheatsheet.el

### DIFF
--- a/meow-cheatsheet.el
+++ b/meow-cheatsheet.el
@@ -173,7 +173,7 @@ NOTE:
                                                     ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 " )
 
-(defun meow--render-cheatshet-thing-table ()
+(defun meow--render-cheatsheet-thing-table ()
   (concat
    (format
     "%s, %s, %s and %s require a %s as input:\n"
@@ -188,7 +188,7 @@ NOTE:
   "Keyboard layout used to display cheatsheet.
 
 Currently `meow-cheatsheet-layout-qwerty', `meow-cheatsheet-layout-dvorak',
-`meow-cheatsheet-layout-dvp' and `meow-cheatsheet-layout-colemak' is supperted.")
+`meow-cheatsheet-layout-dvp' and `meow-cheatsheet-layout-colemak' is supported.")
 
 (defconst meow--cheatsheet-keys
   '("a" "A" "b" "B" "c" "C" "d" "D" "e" "E" "f" "F" "g" "G" "h" "H" "i" "I" "j" "J" "k" "K" "l" "L" "m" "M" "n" "N" "o" "O" "p" "P" "q" "Q" "r" "R" "s" "S" "t" "T" "u" "U" "v" "V" "w" "W" "x" "X" "y" "Y" "z" "Z" "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "!" "@" "" "$" "%" "^" "&" "*" "" "~" "-" "_" "=" "+" "," "<" "." ">" "/" "?" "(" ")" "[" "]" "{" "}" "\\" "|" ";" ":" "'" "\"" "#" "`"))
@@ -239,7 +239,7 @@ Currently `meow-cheatsheet-layout-qwerty', `meow-cheatsheet-layout-dvorak',
       (erase-buffer)
       (insert cheatsheet)
       (insert meow--cheatsheet-note)
-      (insert (meow--render-cheatshet-thing-table))
+      (insert (meow--render-cheatsheet-thing-table))
       (text-mode)
       (setq buffer-read-only t))
     (switch-to-buffer buf)))


### PR DESCRIPTION
This just fixes some minor typos that I spotted when looking through the code that are probably worth fixing