### PR TITLE
Docstring improvements and small typo fixes

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -81,7 +81,7 @@ The direction of selection is MARK -> POS."
       (setq meow--selection selection))))
 
 (defun meow--select-without-history (selection)
-  "Mark the SELECTION without record it in `meow--selection-history'."
+  "Mark the SELECTION without recording it in `meow--selection-history'."
   (-let (((sel-type mark point) selection))
     (goto-char point)
     (if (not sel-type)
@@ -148,13 +148,13 @@ This command supports `meow-selection-command-fallbak'."
 ;;; Buffer
 
 (defun meow-begin-of-buffer ()
-  "Mark from current point, to the beginning of buffer with char selection."
+  "Mark from current point to the beginning of buffer with char selection."
   (interactive)
   (-> (meow--make-selection 'transient (point) (point-min))
       (meow--select)))
 
 (defun meow-end-of-buffer ()
-  "Mark from current point, to the end of buffer with char selection."
+  "Mark from current point to the end of buffer with char selection."
   (interactive)
   (-> (meow--make-selection 'transient (point) (point-max))
       (meow--select)))
@@ -191,7 +191,7 @@ This command supports `meow-selection-command-fallbak'."
 (defun meow-save ()
   "Copy, like command `kill-ring-save'.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (if (region-active-p)
       (meow--with-kill-ring
@@ -203,7 +203,7 @@ This command support `meow-selection-command-fallback'."
 (defun meow-save-append ()
   "Copy, like command `kill-ring-save' but append to lastest kill.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (meow--with-kill-ring
    (let ((select-enable-clipboard nil))
@@ -240,7 +240,7 @@ This command support `meow-selection-command-fallback'."
 (defun meow-cancel-selection ()
   "Cancel selection.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (if (not (region-active-p))
       (meow--selection-fallback)
@@ -249,7 +249,7 @@ This command support `meow-selection-command-fallback'."
 (defun meow-cancel ()
   "Cancel selection or grab.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (cond
    ((region-active-p)
@@ -301,7 +301,7 @@ This command supports `meow-selection-command-fallback'."
            (meow--execute-kbd-macro meow--kbd-kill-region))))))))
 
 (defun meow-kill-append (arg)
-  "Kill region and append to lastest kill.
+  "Kill region and append to latest kill.
 
 This command supports `meow-selection-command-fallback'."
   (interactive "P")
@@ -340,7 +340,7 @@ This command supports `meow-selection-command-fallback'."
 (defun meow-delete ()
   "Delete current region.
 
-This command supports `meow-selection-command-fallbak'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (when (meow--allow-modify-p)
     (if (region-active-p)
@@ -481,7 +481,7 @@ This command supports `meow-selection-command-fallbak'."
     (meow--switch-state 'normal)))
 
 (defun meow-insert ()
-  "Move to the begin of selection, switch to INSERT state."
+  "Move to the start of selection, switch to INSERT state."
   (interactive)
   (if meow--temp-normal
       (progn
@@ -491,7 +491,7 @@ This command supports `meow-selection-command-fallbak'."
     (meow--switch-state 'insert)))
 
 (defun meow-insert-at-begin ()
-  "Move to the begin of line, switch to INSERT state."
+  "Move to the start of line, switch to INSERT state."
   (interactive)
   (if meow--temp-normal
       (progn
@@ -549,7 +549,7 @@ This command supports `meow-selection-command-fallbak'."
 (defun meow-change ()
   "Kill current selection and switch to INSERT state.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (when (meow--allow-modify-p)
     (if (region-active-p)
@@ -574,7 +574,7 @@ This command support `meow-selection-command-fallback'."
 (defun meow-replace ()
   "Replace current selection with yank.
 
-This command support `meow-selection-command-fallback'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (if (not (region-active-p))
       (meow--selection-fallback)
@@ -613,7 +613,7 @@ This command support `meow-selection-command-fallback'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun meow-head (arg)
-  "Move towards to the head of this line.
+  "Move towards the head of this line.
 
 Will cancel all other selection, except char selection.
 
@@ -633,11 +633,11 @@ Use with numeric argument to move multiple chars at once."
         (goto-char bound))))))
 
 (defun meow-tail (arg)
-  "Move towards to the end of this line.
+  "Move towards the end of this line.
 
 Will cancel all other selection, except char selection.
 
-Use with universal argument to move to beginning of line.
+Use with universal argument to move to end of line.
 Use with numeric argument to move multiple chars at once."
   (interactive "P")
   (unless (equal (meow--selection-type) '(expand . char))
@@ -653,7 +653,7 @@ Use with numeric argument to move multiple chars at once."
         (goto-char bound))))))
 
 (defun meow-head-expand (arg)
-  "Activate char selection, then move towards to the head of this line.
+  "Activate char selection, then move towards the head of this line.
 
 See `meow-head' for how prefix arguments work."
   (interactive "P")
@@ -673,7 +673,7 @@ See `meow-head' for how prefix arguments work."
         (goto-char bound))))))
 
 (defun meow-tail-expand (arg)
-  "Activate char selection, then move towards to the end of this line.
+  "Activate char selection, then move towards the end of this line.
 
 See `meow-tail' for how prefix arguments work."
   (interactive "P")
@@ -703,7 +703,7 @@ Will cancel all other selection, except char selection. "
   (call-interactively 'left-char))
 
 (defun meow-right ()
-  "Move to left.
+  "Move to right.
 
 Will cancel all other selection, except char selection. "
   (interactive)
@@ -767,7 +767,7 @@ Use with numeric argument to move multiple lines at once."
       (meow--execute-kbd-macro meow--kbd-forward-line)))))
 
 (defun meow-prev-expand (arg)
-  "Activate char selection, then move to previous line.
+  "Activate char selection, then move to the previous line.
 
 See `meow-prev-line' for how prefix arguments work."
   (interactive "P")
@@ -784,9 +784,9 @@ See `meow-prev-line' for how prefix arguments work."
       (meow--execute-kbd-macro meow--kbd-backward-line)))))
 
 (defun meow-next-expand (arg)
-  "Activate char selection, then move to previous line.
+  "Activate char selection, then move to the next line.
 
-See `meow-prev-line' for how prefix arguments work."
+See `meow-next-line' for how prefix arguments work."
   (interactive "P")
   (if (region-active-p)
       (-> (meow--make-selection '(expand . char) (mark) (point))
@@ -1249,7 +1249,7 @@ Argument REVERSE if selection is reversed."
 
 (defun meow-visit (arg)
   "Mark the search text.
-Argument ARG if not nil, reverse the selection when make selection."
+Argument ARG if not nil, reverse the selection when making selection."
   (interactive "P")
   (let* ((reverse arg)
          (pos (point))
@@ -1276,7 +1276,7 @@ Argument ARG if not nil, reverse the selection when make selection."
   "Select to the beginning of thing represented by CH.
 When EXPAND is non-nil, extend current selection.
 
-Prefix argument is not allow for this command."
+Prefix argument is not allowed for this command."
   (interactive)
   (let ((bounds (meow--parse-inner-of-thing-char
                  (read-char (concat (meow--render-char-thing-table) "\nBeginning of:")))))
@@ -1290,7 +1290,7 @@ Prefix argument is not allow for this command."
    "Select to the beginning of thing represented by CH.
 When EXPAND is non-nil, extend current selection.
 
-Prefix argument is not allow for this command."
+Prefix argument is not allowed for this command."
   (interactive)
   (let ((bounds (meow--parse-inner-of-thing-char
                  (read-char (concat (meow--render-char-thing-table) "\nEnd of:")))))
@@ -1388,7 +1388,7 @@ Argument ARG if not nil, switching in a new window."
     (meow--switch-state 'normal))))
 
 (defun meow-motion-origin-command ()
-  "Execute the origin command bound in special mode."
+  "Execute the original command bound in special mode."
   (interactive)
   (let ((key (string last-input-event)))
     (when-let (cmd (meow--get-origin-command key))
@@ -1446,7 +1446,7 @@ Argument ARG if not nil, switching in a new window."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun meow-start-kmacro ()
-  "Like `kmacro-start-macro', but support record for a region, and apply by lines when finished."
+  "Like `kmacro-start-macro', but supports record for a region, and apply by lines when finished."
   (interactive)
   (if (and (region-active-p) (equal '(expand . line) (meow--selection-type)))
       (progn
@@ -1488,12 +1488,12 @@ Argument ARG if not nil, switching in a new window."
 (defun meow-grab ()
   "Create a grab selection with current selection.
 
-These is used for:
-Grab selection will act like it is the kill-ring. Any Meow command that push string to kill-ring will push string to grab selection. Any Meow command that pop kill-ring will clean the content of grab selection.
+These are used for:
+Grab selection will act like it is the kill-ring. Any Meow command that pushes string to kill-ring will push string to grab selection. Any Meow command that pop kill-ring will clean the content of grab selection.
 
 Also Minibuffer will be filled if the command is listed in `meow-grab-fill-commands'.
 
-The grab will be delete if the owner buffer is not in any window or the grab area become empty(but it's possible to initialize with empty selection).
+The grab will be delete when the owner buffer is not in any window or the grab area becomes empty(but it's possible to initialize with empty selection).
 "
   (interactive)
   (meow--cancel-grab)

--- a/meow-core.el
+++ b/meow-core.el
@@ -81,7 +81,7 @@ This minor mode is used by meow-global-mode, should not be enabled directly."
 
 ;;;###autoload
 (defun meow-indicator ()
-  "Indicator show current mode."
+  "Indicator showing current mode."
   (or meow--indicator (meow--update-indicator)))
 
 ;;;###autoload

--- a/meow-helpers.el
+++ b/meow-helpers.el
@@ -71,9 +71,9 @@ Optional argument ARGS key definitions."
   (add-hook 'meow-insert-mode-hook #'meow--toggle-relative-line-number))
 
 (defun meow-setup-indicator ()
-  "Setup indicator by append the return of function `meow-indicator' to the modeline.
+  "Setup indicator appending the return of function `meow-indicator' to the modeline.
 
-This function should be called after you setup rest parts of mode-line and will work well for most cased.
+This function should be called after you setup other parts of the mode-line and will work well for most cases.
 If this function is not enough for your requirements, use `meow-indicator' to get the raw text for indicator and put it anywhere you want."
   (unless (-contains? mode-line-format '(:eval (meow-indicator)))
     (setq-default mode-line-format (append '((:eval (meow-indicator)) " ") mode-line-format))))

--- a/meow-keymap.el
+++ b/meow-keymap.el
@@ -25,7 +25,7 @@
 (require 'meow-var)
 
 (defvar-local meow--origin-commands nil
-  "Overwirten commands in MOTION state.")
+  "Overwritten commands in MOTION state.")
 
 (defvar meow-keymap
   (let ((keymap (make-sparse-keymap)))

--- a/meow-keypad.el
+++ b/meow-keypad.el
@@ -317,7 +317,7 @@
 (defun meow--keypad-try-execute ()
   "Try execute command.
 
-If there's command available on current key binding, Try replace the last modifier and try again."
+If there is a command available on the current key binding, try replacing the last modifier and try again."
   (unless (or meow--use-literal
               meow--use-meta
               meow--use-both)

--- a/meow-util.el
+++ b/meow-util.el
@@ -46,19 +46,19 @@
 (declare-function meow--cancel-grab "meow-grab")
 
 (defun meow-insert-mode-p ()
-  "If insert mode is enabled."
+  "Whether insert mode is enabled."
   (bound-and-true-p meow-insert-mode))
 
 (defun meow-motion-mode-p ()
-  "If motion mode is enabled."
+  "Whether motion mode is enabled."
   (bound-and-true-p meow-motion-mode))
 
 (defun meow-normal-mode-p ()
-  "If normal mode is enabled."
+  "Whether normal mode is enabled."
   (bound-and-true-p meow-normal-mode))
 
 (defun meow-keypad-mode-p ()
-  "If keypad mode is enabled."
+  "Whether keypad mode is enabled."
   (bound-and-true-p meow-keypad-mode))
 
 (defun meow--set-cursor-color (face)
@@ -69,11 +69,11 @@
         (set-cursor-color color)))))
 
 (defun meow--update-cursor ()
-  "Update cursor type according to current state.
+  "Update cursor type according to the current state.
 
-For performance reason, we save current cursor type to `meow--last-cursor-type' to avoid unnecessary update."
+For performance reasons, we save current cursor type to `meow--last-cursor-type' to avoid unnecessary updates."
   (cond
-   ;; Don't alter cursor-type if it's already hidden
+   ;; Don't alter the cursor-type if it's already hidden
    ((null cursor-type)
     (setq cursor-type meow-cursor-type-default)
     (meow--set-cursor-color 'meow-unknown-cursor))
@@ -97,7 +97,7 @@ For performance reason, we save current cursor type to `meow--last-cursor-type' 
   (alist-get state meow-replace-state-name-list))
 
 (defun meow--render-indicator ()
-  "Minimal indicator show current mode."
+  "Minimal indicator showing current mode."
   (when (bound-and-true-p meow-global-mode)
     (cond
      ((bound-and-true-p meow-keypad-mode)
@@ -165,12 +165,12 @@ For performance reason, we save current cursor type to `meow--last-cursor-type' 
     (exchange-point-and-mark)))
 
 (defun meow--direction-backward-p ()
-  "Return if we have a backward selection."
+  "Return whether we have a backward selection."
   (and (region-active-p)
        (> (mark) (point))))
 
 (defun meow--direction-forward-p ()
-  "Return if we have a forward selection."
+  "Return whether we have a forward selection."
   (and (region-active-p)
        (<= (mark) (point))))
 
@@ -180,13 +180,13 @@ For performance reason, we save current cursor type to `meow--last-cursor-type' 
     (car meow--selection)))
 
 (defun meow--in-string-p (&optional pos)
-  "Return if POS or current position is in string."
+  "Return whether POS or current position is in string."
   (save-mark-and-excursion
     (when pos (goto-char pos))
     (nth 3 (syntax-ppss))))
 
 (defun meow--in-comment-p (&optional pos)
-  "Return if POS or current position is in string."
+  "Return whether POS or current position is in string."
   (save-mark-and-excursion
     (when pos (goto-char pos))
     (nth 4 (syntax-ppss))))
@@ -203,7 +203,7 @@ For performance reason, we save current cursor type to `meow--last-cursor-type' 
     (completing-read prompt list nil nil)))
 
 (defun meow--on-window-state-change (&rest args)
-  "Update cursor style after switch window."
+  "Update cursor style after switching window."
   (meow--update-cursor)
   (meow--grab-maybe-cancel)
   (meow--update-indicator))
@@ -237,7 +237,7 @@ For performance reason, we save current cursor type to `meow--last-cursor-type' 
     (- (point) (line-beginning-position))))
 
 (defun meow--empty-line-p ()
-  "If current line is empty."
+  "Whether current line is empty."
   (string-match-p "^ *$" (buffer-substring-no-properties
                           (line-beginning-position)
                           (line-end-position))))

--- a/meow-var.el
+++ b/meow-var.el
@@ -26,7 +26,7 @@
   "Custom group for meow."
   :group 'meow-module)
 
-;; Behaivors
+;; Behaviors
 
 (defcustom meow-expand-exclude-mode-list
   '(markdown-mode org-mode)
@@ -41,7 +41,7 @@
     (meow-kill . meow-C-k)
     (meow-delete . meow-C-d)
     (meow-cancel-selection . meow-keyboard-quit))
-  "Fallback commands for selection commands when there's no available selection."
+  "Fallback commands for selection commands when there is no available selection."
   :group 'meow
   :type 'list)
 
@@ -55,7 +55,7 @@
   :type 'list)
 
 (defcustom meow-select-on-exit nil
-  "If we activate region when exit INSERT mode.
+  "Whether to activate region when exiting INSERT mode.
 
 If the value is t, a region will be activated.
 Its range is from current point to the point where we enter INSERT mode."
@@ -63,12 +63,12 @@ Its range is from current point to the point where we enter INSERT mode."
   :type 'boolean)
 
 (defcustom meow-expand-hint-remove-delay 1.0
-  "The delay before the position hint disappear."
+  "The delay before the position hint disappears."
   :group 'meow
   :type 'integer)
 
 (defcustom meow-keypad-message t
-  "If log keypad message in minibuffer."
+  "Whether to log keypad messages in minibuffer."
   :group 'meow
   :type 'boolean)
 
@@ -90,13 +90,13 @@ Its range is from current point to the point where we enter INSERT mode."
 
 (defcustom meow-keypad-describe-delay
   0.5
-  "The delay seconds before popup keybinding descriptions."
+  "The delay in seconds before popup keybinding descriptions appear."
   :group 'meow
   :type 'float)
 
 (defcustom meow-grab-fill-commands
   '(meow-query-replace meow-query-replace-regexp)
-  "A list of commands that meow will auto fill with grabed content."
+  "A list of commands that meow will auto fill with grabbed content."
   :group 'meow
   :type 'list)
 
@@ -117,7 +117,7 @@ Commands include: save, replace-save, kill."
   :type 'list)
 
 (defcustom meow-grab-cancel-after-fill t
-  "If cancel grab when fill in minibuffer."
+  "Whether to cancel grab when fill in minibuffer."
   :group 'meow
   :type 'boolean)
 
@@ -133,7 +133,7 @@ Car for buffer have grab selection, Cdr for buffer use grab selection."
   "The function used to describe (KEYMAP) during keypad execution.
 
 To integrate WhichKey-like features with keypad.
-Currently, keypad are not work well with which-key,
+Currently, keypad is not working well with which-key,
 so Meow ships a default `meow-describe-keymap'.
 Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 
@@ -160,11 +160,11 @@ Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 
 ;;; KBD Macros
 ;; We use kbd macro instead of direct command/function invocation,
-;; this allow us not hard code the command/function name.
+;; this allows us to avoid hard coding the command/function name.
 ;;
 ;; The benefit is an out-of-box integration support for other plugins, like: paredit.
 ;;
-;; NOTE: meow is assuming user not modify vanilla Emacs keybindings, otherwise extra complexity will be introduced.
+;; NOTE: meow assumes that the user does not modify vanilla Emacs keybindings, otherwise extra complexity will be introduced.
 
 (defvar meow--kbd-undo "C-/"
   "KBD macro for command `undo'.")
@@ -291,8 +291,8 @@ Use (setq meow-keypad-describe-keymap-function 'nil) to disable popup.")
 
 Has a structure of (sel-type point mark).")
 
-;;; Declare modes we need to activate normal state as default
-;;; Other modes will use motion state as default.
+;;; Declare modes we need to activate normal state as the default
+;;; Other modes will use motion state as the default.
 
 (defvar meow-normal-state-mode-list
   '(fundamental-mode
@@ -312,12 +312,12 @@ Has a structure of (sel-type point mark).")
     deadgrep-edit-mode
     mix-mode
     py-shell-mode)
-  "A list of modes should enable normal state.")
+  "A list of modes that should enable normal state.")
 
 (defvar meow-auto-switch-exclude-mode-list
   '(ripgrep-search-mode
     ivy-occur-grep-mode)
-  "A list of modes don't allow auto switch state.")
+  "A list of modes that don't allow to auto switch state.")
 
 ;;; Search
 
@@ -332,10 +332,10 @@ Has a structure of (sel-type point mark).")
 ;;; Internal variables
 
 (defvar-local meow--temp-normal nil
-  "If we are in temporary normal state. ")
+  "Whether we are in temporary normal state. ")
 
 (defvar meow--selection-history nil
-  "The history of selection.")
+  "The history of selections.")
 
 (defvar meow--expand-nav-function nil
   "Current expand nav function.")
@@ -347,10 +347,10 @@ Has a structure of (sel-type point mark).")
   "Command name for current keypad execution.")
 
 (defvar meow--expanding-p nil
-  "If we are expanding.")
+  "Whether we are expanding.")
 
 (defvar meow--keypad-keymap-description-activated nil
-  "If KEYPAD keymap description is already activated.")
+  "Whether KEYPAD keymap description is already activated.")
 
 (defvar meow--motion-overwrite-keys
   '(" ")

--- a/meow.el
+++ b/meow.el
@@ -29,7 +29,7 @@
 
 ;;; Code:
 
-;;; Dependecies
+;;; Dependencies
 
 (require 'cl-lib)
 (require 'dash)


### PR DESCRIPTION
This pull request contains the remaining set of fixes to docstrings and typos in comments. The main thing to look at carefully are the changes in meow-commands.el. In that file some of the docstrings did not apply to the specific command. I think I fixed them correctly though. 

The only one that isn't clear to me from the docstring is what the universal argument is supposed to do in meow-tail, meow-head, so please double-check carefully that the suggested fix is indeed correct.