### PR TITLE
Some more small fixes for typos

### DIFF
--- a/meow-bounds.el
+++ b/meow-bounds.el
@@ -1,5 +1,22 @@
 ;;; meow-bounds.el --- Calculate bounds in Meow  -*- lexical-binding: t -*-
 
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License
+;; as published by the Free Software Foundation; either version 3
+;; of the License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
 (require 'cl-lib)
 (require 'subr-x)
 (require 'dash)

--- a/meow-grab.el
+++ b/meow-grab.el
@@ -32,7 +32,7 @@
 (defvar meow--grab nil
   "The grab selection.
 
-The value is nil or a overlay.
+The value is nil or an overlay.
 We can only have one grab selection globally.")
 
 (defun meow--update-indicator-for-grab ()
@@ -42,7 +42,7 @@ We can only have one grab selection globally.")
         (window-list)))
 
 (defun meow--create-grab (beg end &optional init)
-  "The selection will be created with the same bounds of current selection, or at current point."
+  "The selection will be created with the same bounds as the current selection, or at current point."
   (let* ((beg (or beg (if (region-active-p) (region-beginning) (point))))
          (end (or end (if (region-active-p) (region-end) (point))))
          (ov (make-overlay beg end)))
@@ -64,13 +64,13 @@ We can only have one grab selection globally.")
   (meow--update-indicator-for-grab))
 
 (defun meow--own-grab-p ()
-  "If grab selection is in current buffer."
+  "Whether grab selection is in current buffer."
   (and meow--grab
        (equal (current-buffer)
               (overlay-buffer meow--grab))))
 
 (defun meow--has-grab-p ()
-  "If grab selection is available.
+  "Whether grab selection is available.
 
 The grab selection will only be available when it is visible in a window."
   (and meow--grab

--- a/meow-shims.el
+++ b/meow-shims.el
@@ -19,7 +19,7 @@
 
 ;;; Commentary:
 ;; The file contains all the shim code we need to make meow
-;; working with other packages.
+;; work with other packages.
 
 ;;; Code:
 
@@ -36,7 +36,7 @@
 ;; eldoc
 
 (defvar meow--eldoc-setup nil
-  "If already setup eldoc.")
+  "Whether already setup eldoc.")
 
 (defconst meow--eldoc-commands
   '(meow-head
@@ -49,10 +49,10 @@
     meow-append
     meow-open-below
     meow-open-above)
-  "A list meow commands trigger eldoc.")
+  "A list of meow commands that trigger eldoc.")
 
 (defun meow--setup-eldoc (enable)
-  "Setup commands those trigger eldoc.
+  "Setup commands that trigger eldoc.
 Basically, all navigation commands should trigger eldoc."
   (setq meow--eldoc-setup enable)
   (if enable
@@ -63,7 +63,7 @@ Basically, all navigation commands should trigger eldoc."
 ;; company
 
 (defvar meow--company-setup nil
-  "If already setup company.")
+  "Whether already setup company.")
 
 (declare-function company--active-p "company")
 (declare-function company-abort "company")
@@ -86,7 +86,7 @@ Basically, all navigation commands should trigger eldoc."
 ;; wgrep
 
 (defvar meow--wgrep-setup nil
-  "If already setup wgrep.")
+  "Whether already setup wgrep.")
 
 (defun meow--wgrep-to-normal (&rest ignore)
   "Switch to normal state, used in advice for wgrep.
@@ -118,7 +118,7 @@ We use advice here because wgrep doesn't call its hooks."
 ;; yasnippet
 
 (defvar meow--yasnippet-setup nil
-  "If already setup yasnippet.")
+  "Whether already setup yasnippet.")
 
 (defun meow--setup-yasnippet (enable)
   "Setup for yasnippet."
@@ -131,7 +131,7 @@ We use advice here because wgrep doesn't call its hooks."
 ;; rectangle-mark-mode
 
 (defvar meow--rectangle-mark-setup nil
-  "If already setup rectangle-mark.")
+  "Whether already setup rectangle-mark.")
 
 (defun meow--rectangle-mark-init ()
   (when (bound-and-true-p rectangle-mark-mode)
@@ -147,10 +147,10 @@ We use advice here because wgrep doesn't call its hooks."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; paredit-mode
 ;; Paredit will rebind (, [, { to make them insert paired parentheses.
-;; However, it's every common for Meow to having an activated region, in this case,
+;; However, it's very common for Meow to having an activated region, in this case,
 ;; paredit will wrap the region with parentheses, this is inconvenient for our case.
 ;; Since we have modal editing and keypad mode, wrap could be done use SPC m (.
-;; So we replace theses commands in paredit-mode with our implementations.
+;; So we replace these commands in paredit-mode with our implementations.
 
 (declare-function paredit-open-round "paredit")
 (declare-function paredit-open-square "paredit")
@@ -158,7 +158,7 @@ We use advice here because wgrep doesn't call its hooks."
 (declare-function paredit-open-angled "paredit")
 
 (defvar meow--paredit-setup nil
-  "If already setup paredit.")
+  "Whether already setup paredit.")
 
 (defun meow-paredit-open-angled ()
   (interactive)
@@ -197,7 +197,7 @@ We use advice here because wgrep doesn't call its hooks."
 ;; Enable / Disable shims
 
 (defun meow--enable-shims ()
-  ;; This let us start input without cancel selection.
+  ;; This lets us start input without canceling selection.
   ;; We will backup `delete-active-region'.
   (setq meow--backup-var-delete-activae-region delete-active-region)
   (setq delete-active-region nil)

--- a/meow-shims.el
+++ b/meow-shims.el
@@ -199,7 +199,7 @@ We use advice here because wgrep doesn't call its hooks."
 (defun meow--enable-shims ()
   ;; This lets us start input without canceling selection.
   ;; We will backup `delete-active-region'.
-  (setq meow--backup-var-delete-activae-region delete-active-region)
+  (setq meow--backup-var-delete-activate-region delete-active-region)
   (setq delete-active-region nil)
   (delete-selection-mode -1)
   (meow--setup-eldoc t)
@@ -210,7 +210,7 @@ We use advice here because wgrep doesn't call its hooks."
   (with-eval-after-load "paredit" (meow--setup-paredit t)))
 
 (defun meow--disable-shims ()
-  (setq delete-active-region meow--backup-var-delete-activae-region)
+  (setq delete-active-region meow--backup-var-delete-activate-region)
   (when meow--eldoc-setup (meow--setup-eldoc nil))
   (when meow--rectangle-mark-setup (meow--setup-rectangle-mark nil))
   (when meow--company-setup (meow--setup-company nil))

--- a/meow-visual.el
+++ b/meow-visual.el
@@ -81,7 +81,7 @@ Value is a list of (last-regexp last-pos idx cnt).")
 (defun meow--highlight-regexp-in-buffer (regexp)
   "Highlight all regexp in this buffer.
 
-There is a cache mechanism, if the REGEXP is not changed, we simplily inc/dec idx and redraw the overlays. Only count for the first time."
+There is a cache mechanism, if the REGEXP is not changed, we simply inc/dec idx and redraw the overlays. Only count for the first time."
   (when (region-active-p)
     (-let ((cnt 0)
            (idx 0)
@@ -111,7 +111,7 @@ There is a cache mechanism, if the REGEXP is not changed, we simplily inc/dec id
           (meow--show-indicator pos idx cnt)
           (setq meow--search-indicator-state (list regexp pos idx cnt))))
 
-       ;; For initializing searching highlight, we need to count
+       ;; For initializing search highlight, we need to count
        (t
         (save-mark-and-excursion
           (meow--remove-search-indicator)
@@ -204,8 +204,8 @@ There is a cache mechanism, if the REGEXP is not changed, we simplily inc/dec id
                            (cdr nav-functions))))
       (meow--highlight-num-positions-1 nav-function faces bound)
       ;; sit-for is disabled when recording kmacros,
-      ;; we use this fallback behavior which remove highlight after delay seconds
-      ;; Meow don't use pre/post-command-hook for performance reason.
+      ;; we use this fallback behavior which removes highlight after delay seconds
+      ;; Meow doesn't use pre/post-command-hook for performance reason.
       (if defining-kbd-macro
           (run-at-time
            (time-add (current-time)


### PR DESCRIPTION
Some more typo and grammar fixes in files that I had forgotten to look at.

btw) one of those files lacked the standard copyright clause. This is also fixed.