### PR TITLE
Fix a wrong direction in a docstring

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -1298,7 +1298,7 @@ Prefix argument is not allowed for this command."
          (meow--select)))))
 
 (defun meow-end-of-thing ()
-   "Select to the beginning of thing represented by CH.
+   "Select to the end of thing represented by CH.
 When EXPAND is non-nil, extend current selection.
 
 Prefix argument is not allowed for this command."

--- a/meow-command.el
+++ b/meow-command.el
@@ -133,7 +133,7 @@ The direction of selection is MARK -> POS."
 (defun meow-reverse ()
   "Just exchange point and mark.
 
-This command supports `meow-selection-command-fallbak'."
+This command supports `meow-selection-command-fallback'."
   (interactive)
   (if (not (region-active-p))
       (meow--selection-fallback)


### PR DESCRIPTION
Title says it all; I spotted a docstring that wasn't fully correct. This commit fixes that.