### PR TITLE
Update meow-command.el

### DIFF
--- a/meow-command.el
+++ b/meow-command.el
@@ -41,7 +41,8 @@
       (call-interactively ret))
 
      ((and (not meow-use-keypad-when-execute-kbd) (keymapp ret))
-      (set-transient-map ret nil nil))
+      (setq which-key-show-transient-maps t)
+      (set-transient-map ret nil (lambda()(setq which-key-show-transient-maps nil))))
 
      ((and meow-use-keypad-when-execute-kbd (keymapp ret))
       (meow--switch-state 'keypad)


### PR DESCRIPTION
执行KEy-map时 临时开启which-key的transient-maps显示，退出后关闭显示。一直开transient-maps显示会对影响其他包中也使用transient-maps的操作结果。比如:i-search-forwar