### PR TITLE
fix emacs28 warning

### DIFF
--- a/meow-core.el
+++ b/meow-core.el
@@ -36,24 +36,24 @@
 ;;;###autoload
 (define-minor-mode meow-insert-mode
   "Meow Insert state."
-  nil
-  " [I]"
+  :init-value nil
+  :lighter " [I]"
   meow-insert-state-keymap
   (meow--insert-init))
 
 ;;;###autoload
 (define-minor-mode meow-normal-mode
   "Meow Normal state."
-  nil
-  " [N]"
+  :init-value nil
+  :lighter " [N]"
   meow-normal-state-keymap
   (meow--normal-init))
 
 ;;;###autoload
 (define-minor-mode meow-keypad-mode
   "Meow keypad state."
-  nil
-  " [K]"
+  :init-value nil
+  :lighter " [K]"
   ;; use overriding-local-map for highest keymap priority
   ;; so KEYPAD won't be affected by overlays' keymap
   meow-keypad-state-keymap
@@ -62,8 +62,8 @@
 ;;;###autoload
 (define-minor-mode meow-motion-mode
   "Meow motion state."
-  nil
-  " [M]"
+  :init-value nil
+  :lighter " [M]"
   meow-motion-state-keymap
   (meow--motion-init))
 
@@ -72,8 +72,8 @@
   "Meow minor mode.
 
 This minor mode is used by meow-global-mode, should not be enabled directly."
-  nil
-  nil
+  :init-value nil
+  :global nil
   meow-keymap
   (if meow-mode
       (meow--enable)

--- a/meow-core.el
+++ b/meow-core.el
@@ -38,7 +38,7 @@
   "Meow Insert state."
   :init-value nil
   :lighter " [I]"
-  meow-insert-state-keymap
+  :keymap meow-insert-state-keymap
   (meow--insert-init))
 
 ;;;###autoload
@@ -46,7 +46,7 @@
   "Meow Normal state."
   :init-value nil
   :lighter " [N]"
-  meow-normal-state-keymap
+  :keymap meow-normal-state-keymap
   (meow--normal-init))
 
 ;;;###autoload
@@ -56,7 +56,7 @@
   :lighter " [K]"
   ;; use overriding-local-map for highest keymap priority
   ;; so KEYPAD won't be affected by overlays' keymap
-  meow-keypad-state-keymap
+  :keymap meow-keypad-state-keymap
   (meow--keypad-init))
 
 ;;;###autoload
@@ -64,7 +64,7 @@
   "Meow motion state."
   :init-value nil
   :lighter " [M]"
-  meow-motion-state-keymap
+  :keymap meow-motion-state-keymap
   (meow--motion-init))
 
 ;;;###autoload
@@ -74,7 +74,7 @@
 This minor mode is used by meow-global-mode, should not be enabled directly."
   :init-value nil
   :global nil
-  meow-keymap
+  :keymap meow-keymap
   (if meow-mode
       (meow--enable)
     (meow--disable)))


### PR DESCRIPTION
Fix deprecated params passed to define-minor mode.
In Emacs 28, there was always warning massages on startup as below:
```
meow-core.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'
```